### PR TITLE
fix http response 403 Forbidden for freshclam update

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,9 +54,9 @@ function freshclam() {
   # Update files if they are missing or older that X days
   if [[ ! -f "/var/lib/clamav/daily.cvd" ]]; then
     echo "Clamd files are missing. Updating..."
-    wget -t 5 -T 99999 -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd
-    wget -t 5 -T 99999 -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd
-    wget -t 5 -T 99999 -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd
+    wget --user-agent='Mozilla/5.0 (clamav)' -t 5 -T 99999 -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd
+    wget --user-agent='Mozilla/5.0 (clamav)' -t 5 -T 99999 -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd
+    wget --user-agent='Mozilla/5.0 (clamav)' -t 5 -T 99999 -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd
   else
     echo "File clamd files exists"
   fi


### PR DESCRIPTION
fix http response 403 Forbidden for freshclam update by adding user-agent header
The update server seems to require a user-agent to accept the request.
This agent name works, might be changed to something more suitable. Anyhow one must be set.

HTH